### PR TITLE
man: exit cleanly on interactive cancellation

### DIFF
--- a/cmd/man.rb
+++ b/cmd/man.rb
@@ -203,7 +203,10 @@ module Homebrew
           pipe.close_write
           pipe.read
         end.to_s.strip
-        odie "No selection made." if result.empty?
+        if result.empty?
+          $stderr.puts "No selection made." if args.verbose?
+          exit 0
+        end
 
         # Extract the index from the "N) " prefix
         match = result.match(/\A\s*(\d+)\)/)
@@ -238,7 +241,10 @@ module Homebrew
               $stdout.write "Choose [1-#{choices.length}] (or 'l' to re-list): "
               $stdout.flush
               input = tty.gets
-              odie "No selection made." if input.nil?
+              if input.nil?
+                $stderr.puts "No selection made." if args.verbose?
+                exit 0
+              end
 
               if input.strip.casecmp("l").zero?
                 page_list(list_text)
@@ -257,7 +263,10 @@ module Homebrew
           $stdout.write "Choose [1-#{choices.length}]: "
           $stdout.flush
           input = $stdin.gets
-          odie "No selection made." if input.nil?
+          if input.nil?
+            exit 1 if args.quiet?
+            odie "brew man: --interactive requires a TTY"
+          end
 
           index = input.strip.to_i - 1
           odie "Invalid selection." if index.negative? || index >= choices.length

--- a/cmd/man.rb
+++ b/cmd/man.rb
@@ -170,6 +170,15 @@ module Homebrew
         end
       end
 
+      # The user deliberately made no selection (fzf Escape/Ctrl-C, fzf with
+      # no matching entry, or EOF at the TTY prompt): exit cleanly, with a
+      # notice only under --verbose (see docs/decisions/0003).
+      sig { returns(T.noreturn) }
+      def exit_no_selection
+        $stderr.puts "No selection made." if args.verbose?
+        exit 0
+      end
+
       # Uses fzf for fuzzy interactive selection.
       sig {
         params(
@@ -204,8 +213,15 @@ module Homebrew
           pipe.read
         end.to_s.strip
         if result.empty?
-          $stderr.puts "No selection made." if args.verbose?
-          exit 0
+          # fzf exit statuses (fzf(1)): 0 selection, 1 no match, 2 error,
+          # 130 interrupted (Escape or Ctrl-C). "No match" and "interrupted"
+          # are both the user declining to select; anything else with empty
+          # output is a real fzf failure and must not masquerade as a clean
+          # cancellation.
+          exit_status = Process.last_status&.exitstatus
+          odie "fzf exited with status #{exit_status}." if exit_status && [1, 130].exclude?(exit_status)
+
+          exit_no_selection
         end
 
         # Extract the index from the "N) " prefix
@@ -241,10 +257,7 @@ module Homebrew
               $stdout.write "Choose [1-#{choices.length}] (or 'l' to re-list): "
               $stdout.flush
               input = tty.gets
-              if input.nil?
-                $stderr.puts "No selection made." if args.verbose?
-                exit 0
-              end
+              exit_no_selection if input.nil?
 
               if input.strip.casecmp("l").zero?
                 page_list(list_text)

--- a/docs/decisions/0003-brew-man-interactive-cancellation.md
+++ b/docs/decisions/0003-brew-man-interactive-cancellation.md
@@ -1,0 +1,101 @@
+---
+# SPDX-FileCopyrightText: Copyright 2026 Todd Schulman
+#
+# SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+
+number: 3
+title: "`brew man --interactive` cancellation exit behavior"
+status: accepted
+date: 2026-04-21
+decision-makers:
+  - toobuntu
+---
+
+# `brew man --interactive` cancellation exit behavior
+
+## Context and Problem Statement
+
+`brew man --interactive` presents an fzf selector (or a paged TTY fallback) for
+choosing a man page. Three code paths exist where the user makes no selection:
+
+1. **fzf Escape / Ctrl+C** — fzf exits with code 130 and returns empty output
+2. **TTY EOF (Ctrl+D)** — `/dev/tty` `gets` returns `nil`
+3. **Non-TTY nil stdin** — stdin is not a TTY; interactive selection is
+   structurally impossible
+
+The original code called `odie "No selection made."` in all three paths, which
+printed `Error: No selection made.` to stderr and exited 1 — treating a
+deliberate user cancellation the same as a hard failure.
+
+Cases 1 and 2 are user-initiated dismissals. Case 3 is different: the command
+was invoked in a mode it cannot fulfill (no TTY means interactive selection is
+structurally impossible). What should the exit code and diagnostic output be for
+each path?
+
+## Decision Outcome
+
+Chosen option: differentiate user cancellation (exit 0) from environmental
+precondition failure (exit 1), because exit codes should reflect *why* execution
+ended, not merely *that* it ended without a result.
+
+| Case | Exit code | Message |
+|---|---|---|
+| fzf Escape / Ctrl+C (empty output) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
+| TTY EOF (Ctrl+D) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
+| Non-TTY nil stdin | 1 | `Error: brew man: --interactive requires a TTY` (stderr, suppressed by `--quiet`) |
+
+### Consequences
+
+* Good, because users pressing Escape or Ctrl+D see no output — consistent with
+  how interactive Unix tools (fzf, vim, git interactive rebase) behave on
+  cancellation.
+* Good, because `--verbose` users see `No selection made.` on stderr, confirming
+  the command ran and exited cleanly without a selection.
+* Good, because a caller piping or scripting `brew man --interactive` in a
+  non-TTY context receives exit 1 and an error message, suppressible with
+  `--quiet` while still observing the exit code.
+* Neutral, because `--debug` behavior is unchanged; no additional output is
+  emitted for these paths at the debug level.
+
+## More Information
+
+The correct implementation for Cases 1 and 2 is:
+
+```ruby
+$stderr.puts "No selection made." if args.verbose?
+exit 0
+```
+
+No `Utils::Output::Mixin` method maps to this combination of verbose-gating,
+stderr destination, and neutral informational register (see reference table
+below). Forcing a fit onto an existing mixin trades semantic correctness for
+cosmetic idiomaticity — the worse tradeoff.
+
+### `Utils::Output::Mixin` method map
+
+Source: [`utils/output.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/output.rb)
+Docs: <https://docs.brew.sh/rubydoc/Utils/Output/Mixin.html>
+
+| Method | Destination | Prefix / format | Flag gate | Exit effect |
+|---|---|---|---|---|
+| `ohai(title, *sput)` | **stdout** | `==>` bold blue; truncated unless `--verbose` or non-TTY | None (unconditional) | None |
+| `oh1(title, truncate: :auto)` | **stdout** | `==>` bold green; same truncation logic | None (unconditional) | None |
+| `odebug(title, *sput, always_display: false)` | **stderr** | Bold magenta headline (no label) | `--debug` (or `always_display: true`) | None |
+| `opoo(message)` | **stderr** | `Warning:` yellow | None (unconditional) | None |
+| `opoo_outside_github_actions(message)` | **stderr** | `Warning:` yellow | None, but suppressed entirely in GitHub Actions | None |
+| `onoe(message)` | **stderr** | `Error:` red | None (unconditional) | None |
+| `ofail(error)` | **stderr** (via `onoe`) | `Error:` red | None (unconditional) | Sets `Homebrew.failed = true`; deferred exit 1 at program end |
+| `odie(error)` | **stderr** (via `onoe`) | `Error:` red | None (unconditional) | **Immediate** `exit 1` |
+
+Notable gaps relevant to this ADR:
+
+- No method is both **verbose-gated** and writes to **stderr**.
+- `odebug` with `always_display: true` and an `if args.verbose?` guard was
+  considered: it reaches stderr but applies magenta headline formatting
+  inappropriate for a plain status notice, and the double-gating (mixin's own
+  debug check plus the explicit verbose guard) is confusing.
+- `ohai` / `oh1` with `if args.verbose?` was considered: verbose-gated but
+  writes to stdout and carries step-announcement weight (`==>`) that
+  overstates a soft cancellation notice.
+- `$stderr.puts … if args.verbose?` is raw Ruby but is the most accurate
+  expression of the intent.

--- a/docs/decisions/0003-brew-man-interactive-cancellation.md
+++ b/docs/decisions/0003-brew-man-interactive-cancellation.md
@@ -40,9 +40,18 @@ ended, not merely *that* it ended without a result.
 
 | Case | Exit code | Message |
 |---|---|---|
-| fzf Escape / Ctrl+C (empty output) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
+| fzf Escape / Ctrl+C (empty output, fzf exit 130) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
+| fzf no matching entry (empty output, fzf exit 1) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
 | TTY EOF (Ctrl+D) | 0 | `$stderr.puts "No selection made."` if `--verbose` |
 | Non-TTY nil stdin | 1 | `Error: brew man: --interactive requires a TTY` (stderr, suppressed by `--quiet`) |
+| fzf failure (empty output, any other fzf exit status) | 1 | `Error: fzf exited with status <N>.` via `odie` |
+
+The implementation distinguishes these by checking fzf's exit status
+(`Process.last_status`) whenever fzf produced empty output: per fzf(1),
+0 is a selection, 1 is "no match", 2 is an error, and 130 is
+"interrupted with Ctrl-C or Escape". Statuses 1 and 130 are the user
+declining to select; anything else with empty output is a real fzf
+failure and must not masquerade as a clean cancellation.
 
 ### Consequences
 

--- a/test/cmd/man_spec.rb
+++ b/test/cmd/man_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe Homebrew::Cmd::Man do
       expect(result).to eq(manfile)
     end
 
-    it "dies when fzf returns empty output" do
+    it "exits cleanly when fzf returns no selection" do
       choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
       pipe = instance_double(IO)
       allow(IO).to receive(:popen).with(array_including("/usr/bin/fzf"), "r+").and_yield(pipe)
@@ -543,7 +543,25 @@ RSpec.describe Homebrew::Cmd::Man do
                                                    fzf_path: Pathname("/usr/bin/fzf")) do |label, file, i|
           "  #{i + 1}) #{label}: #{file}"
         end
-      end.to raise_error(SystemExit)
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "prints 'No selection made.' to stderr when --verbose and fzf returns no selection" do
+      verbose_cmd = described_class.new(["some-formula", "--verbose"])
+      choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
+      pipe = instance_double(IO)
+      allow(IO).to receive(:popen).with(array_including("/usr/bin/fzf"), "r+").and_yield(pipe)
+      allow(pipe).to receive(:write)
+      allow(pipe).to receive(:close_write)
+      allow(pipe).to receive(:read).and_return("")
+
+      expect($stderr).to receive(:puts).with("No selection made.")
+      expect do
+        verbose_cmd.send(:interactive_select_fzf, choices, header:   "test:",
+                                                           fzf_path: Pathname("/usr/bin/fzf")) do |label, file, i|
+          "  #{i + 1}) #{label}: #{file}"
+        end
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
     end
 
     it "writes candidate lines to fzf stdin and closes write end" do
@@ -587,15 +605,30 @@ RSpec.describe Homebrew::Cmd::Man do
       end.to raise_error(SystemExit)
     end
 
-    it "dies on EOF in non-TTY mode" do
+    it "exits with error and emits message on EOF in non-TTY mode" do
       choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
       allow($stdin).to receive(:gets).and_return(nil)
+      expect($stderr).to receive(:puts)
+        .with(a_string_including("brew man: --interactive requires a TTY"))
 
       expect do
         cmd.send(:interactive_select_paged, choices, header: "test:") do |label, file, i|
           "  #{i + 1}) #{label}: #{file}"
         end
-      end.to raise_error(SystemExit)
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+
+    it "exits 1 silently on EOF in non-TTY mode when quiet" do
+      quiet_cmd = described_class.new(["some-formula", "--quiet"])
+      choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
+      allow($stdin).to receive(:gets).and_return(nil)
+      expect($stderr).not_to receive(:puts)
+
+      expect do
+        quiet_cmd.send(:interactive_select_paged, choices, header: "test:") do |label, file, i|
+          "  #{i + 1}) #{label}: #{file}"
+        end
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
     end
 
     context "when stdout is a TTY" do
@@ -643,7 +676,7 @@ RSpec.describe Homebrew::Cmd::Man do
         end.to raise_error(SystemExit)
       end
 
-      it "dies on EOF from /dev/tty" do
+      it "exits cleanly on EOF from /dev/tty" do
         choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
         tty_io = StringIO.new
         allow(File).to receive(:open).with("/dev/tty", "r").and_yield(tty_io)
@@ -653,7 +686,22 @@ RSpec.describe Homebrew::Cmd::Man do
           cmd.send(:interactive_select_paged, choices, header: "test:") do |label, file, i|
             "  #{i + 1}) #{label}: #{file}"
           end
-        end.to raise_error(SystemExit)
+        end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+      end
+
+      it "prints 'No selection made.' to stderr when --verbose and /dev/tty reaches EOF" do
+        verbose_cmd = described_class.new(["some-formula", "--verbose"])
+        choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
+        tty_io = StringIO.new
+        allow(File).to receive(:open).with("/dev/tty", "r").and_yield(tty_io)
+        allow(verbose_cmd).to receive(:page_list)
+
+        expect($stderr).to receive(:puts).with("No selection made.")
+        expect do
+          verbose_cmd.send(:interactive_select_paged, choices, header: "test:") do |label, file, i|
+            "  #{i + 1}) #{label}: #{file}"
+          end
+        end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
       end
     end
   end

--- a/test/cmd/man_spec.rb
+++ b/test/cmd/man_spec.rb
@@ -537,6 +537,8 @@ RSpec.describe Homebrew::Cmd::Man do
       allow(pipe).to receive(:write)
       allow(pipe).to receive(:close_write)
       allow(pipe).to receive(:read).and_return("")
+      allow(Process).to receive(:last_status)
+        .and_return(instance_double(Process::Status, exitstatus: 130))
 
       expect do
         cmd.send(:interactive_select_fzf, choices, header:   "test:",
@@ -554,6 +556,8 @@ RSpec.describe Homebrew::Cmd::Man do
       allow(pipe).to receive(:write)
       allow(pipe).to receive(:close_write)
       allow(pipe).to receive(:read).and_return("")
+      allow(Process).to receive(:last_status)
+        .and_return(instance_double(Process::Status, exitstatus: 130))
 
       expect($stderr).to receive(:puts).with("No selection made.")
       expect do
@@ -562,6 +566,42 @@ RSpec.describe Homebrew::Cmd::Man do
           "  #{i + 1}) #{label}: #{file}"
         end
       end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "treats fzf 'no match' (exit 1) with empty output as no selection" do
+      choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
+      pipe = instance_double(IO)
+      allow(IO).to receive(:popen).with(array_including("/usr/bin/fzf"), "r+").and_yield(pipe)
+      allow(pipe).to receive(:write)
+      allow(pipe).to receive(:close_write)
+      allow(pipe).to receive(:read).and_return("")
+      allow(Process).to receive(:last_status)
+        .and_return(instance_double(Process::Status, exitstatus: 1))
+
+      expect do
+        cmd.send(:interactive_select_fzf, choices, header:   "test:",
+                                                   fzf_path: Pathname("/usr/bin/fzf")) do |label, file, i|
+          "  #{i + 1}) #{label}: #{file}"
+        end
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "dies when fzf fails with empty output and a non-cancellation status" do
+      choices = [["system", Pathname("/usr/share/man/man1/testcmd.1")]]
+      pipe = instance_double(IO)
+      allow(IO).to receive(:popen).with(array_including("/usr/bin/fzf"), "r+").and_yield(pipe)
+      allow(pipe).to receive(:write)
+      allow(pipe).to receive(:close_write)
+      allow(pipe).to receive(:read).and_return("")
+      allow(Process).to receive(:last_status)
+        .and_return(instance_double(Process::Status, exitstatus: 2))
+
+      expect do
+        cmd.send(:interactive_select_fzf, choices, header:   "test:",
+                                                   fzf_path: Pathname("/usr/bin/fzf")) do |label, file, i|
+          "  #{i + 1}) #{label}: #{file}"
+        end
+      end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
     end
 
     it "writes candidate lines to fzf stdin and closes write end" do


### PR DESCRIPTION
Re-lands the `brew man --interactive` cancellation behavior from #36 on current main, with ADR 0003 in MADR format. The ADR-tooling half of #36 is being reconciled into repo-foundation (W1). Behavior: fzf Escape / TTY EOF exit 0 (verbose-only stderr notice); non-TTY nil stdin exits 1 (`--quiet` suppresses the message). Verified: brew style, REUSE, adrs doctor, brew tests --only=cmd/man (92 examples).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `brew man --interactive` now exits cleanly with no selection for both selector “no match” and user cancellation cases.
  * Verbose mode now prints “No selection made.” to standard error; non-verbose avoids extra stderr output.
  * Non-TTY stdin and EOF handling now produces clearer, more accurate exit statuses and messages (quiet mode suppresses errors).
* **Documentation**
  * Added an ADR defining cancellation/no-selection stderr and exit-code behavior for `--interactive`.
* **Tests**
  * Expanded coverage for fzf and TTY/non-TTY EOF and empty-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->